### PR TITLE
"tomorrow’s" rather than "tomorrow's"

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,6 +1,6 @@
 ---
 template: Simple
-title: cssnext - Use tomorrow's CSS syntax, today.
+title: cssnext - Use tomorrow&rsquo;s CSS syntax, today.
 ---
 <div class="cssnext-Jumbotron cssnext-Jumbotron--default cssnext-Center cssnext-Light">
   <section class="r-Grid">


### PR DESCRIPTION
Using HTML entity `&lsquo;` rather than hard coding. Should be able to hard code with ’ if you'd rather, as page character set defined as utf 8.